### PR TITLE
Download issue

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -8,8 +8,7 @@ share {
 	requires 'Alien::gmake' => 0.14;
 
 	plugin Download => (
-		url => 'ftp://ftp.unidata.ucar.edu/pub/udunits/',
-		version => qr/udunits-([\d\.]+)\.tar\.gz/,
+		url => 'https://www.unidata.ucar.edu/downloads/udunits/udunits-2.2.26.tar.gz',
 	);
 
 	plugin Extract => 'tar.gz';


### PR DESCRIPTION
Hello :smile: 

Thank you a lot for this Alien module :)

I propose this change to force the download plugin to take the http link !

It is to fix this kind of [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/631565212?check_suite_focus=true)

If I do only this : 
```
plugin Download => (
		url => 'https://www.unidata.ucar.edu/downloads/udunits/',
		version => qr/udunits-([\d\.]+)\.tar\.gz/,
	);
```

Which seems better...

It seems it scrapes the page and choose ftp as prefered link... and fails later with `Could not find any matching files at /usr/local/share/perl/5.26.1/Alien/Base/ModuleBuild.pm line 442.`

/ cc @plicease 

Best regards.

Thibault